### PR TITLE
Codemaster queue for non-shuffle

### DIFF
--- a/src/Global.-1.ttslua
+++ b/src/Global.-1.ttslua
@@ -705,19 +705,19 @@ local players = {}
   local reinsert = {}
 
   for i, seat in ipairs(seats) do
-    if seat.seated then
+    if Player[seat].seated then
       table.insert(free, seat)
     else
       table.insert(swap, seat)
     end
   end
 
-  shufflingPlayer = true
+  shufflingPlayers = true
   for i = 1,2 do
     if #codemasterQueue < 1 then break end
     count = 0
     if #free > 0 then
-      randSeat = math.random(0,#free)
+      randSeat = math.random(1,#free)
       seat = free[randSeat]
       table.remove(free,randSeat)
       for _, player in ipairs(Player.getPlayers()) do
@@ -735,7 +735,7 @@ local players = {}
         coroutine.yield(0)
       end
     else
-      randSeat = math.random(0,#swap)
+      randSeat = math.random(1,#swap)
       seat = swap[randSeat]
       table.remove(swap,randSeat)
       for _, player in ipairs(Player.getPlayers()) do

--- a/src/Global.-1.ttslua
+++ b/src/Global.-1.ttslua
@@ -683,8 +683,8 @@ function shufflePlayers(o, color)
   end
 end
 
-function sleep(s)
-  for i=1,s do
+function sleep(t)
+  for i=1,t do
     coroutine.yield(0)
   end
 end
@@ -830,15 +830,10 @@ function startShuffle()
       end
     end
 
-    -- Stand all players
-    count = 0
+    -- Stand all player
     for _, player in ipairs(players) do
       player.changeColor("Grey")
-      while count < 5 do
-          count = count + 1
-          coroutine.yield(0)
-      end
-      count = 0
+      sleep(5)
     end
 
     -- Sit players back down
@@ -863,11 +858,7 @@ function startShuffle()
         table.remove(players, playerIndex)
         randPlayer.changeColor(seat)
       end
-      while count < 5 do
-        count = count + 1
-        coroutine.yield(0)
-      end
-      count = 0
+      sleep(5)
     end
 
     for _, player in ipairs(reinsert) do table.insert(codemasterQueue,player) end
@@ -876,11 +867,8 @@ function startShuffle()
     redrawQueue()
 
     -- Delay afterwards
-    count = 0
-    while count < 250 do
-        count = count + 1
-        coroutine.yield(0)
-    end
+
+    sleep(250)
 
 
     -- Continue game setup if in progress

--- a/src/Global.-1.ttslua
+++ b/src/Global.-1.ttslua
@@ -730,23 +730,21 @@ local players = {}
   for i = 1,2 do
     if #codemasterQueue < 1 then break end
     if #free > 0 then
-      randSeat = math.random(1,#free)
-      seat = free[randSeat]
-      table.remove(free,randSeat)
-
-      player = findPlayerBySteamID(codemasterQueue[1].steam_id)
-      player.changeColor(seat)
-      if codemasterQueue[1].stay then
-        table.insert(reinsert,table.remove(codemasterQueue,1))
-      else
-        table.remove(codemasterQueue,1)
-      end
+      seat = table.remove(free,math.random(1,#free))
     else
-      randSeat = math.random(1,#swap)
-      seat = swap[randSeat]
-      table.remove(swap,randSeat)
-      player = findPlayerBySteamID(codemasterQueue[1].steam_id)
-      if player == Player[seat] then break end
+      seat = table.remove(swap,math.random(1,#swap))
+    end
+
+    player = findPlayerBySteamID(codemasterQueue[1].steam_id)
+    if codemasterQueue[1].stay then
+      table.insert(reinsert,table.remove(codemasterQueue,1))
+    else
+      table.remove(codemasterQueue,1)
+    end
+
+    if not Player[seat].seated then
+      player.changeColor(seat)
+    elseif not player.color == seat then
       oldPlayer = Player[seat]
       oldColor = player.color
 

--- a/src/Global.-1.ttslua
+++ b/src/Global.-1.ttslua
@@ -718,6 +718,7 @@ local players = {}
   local swap = {}
   local reinsert = {}
 
+  --Sort seats to prefer empty seats
   for i, seat in ipairs(seats) do
     if not Player[seat].seated then
       table.insert(free, seat)
@@ -727,15 +728,21 @@ local players = {}
   end
 
   shufflingPlayers = true
+  --run up to 2 times
   for i = 1,2 do
+    --if the queue is empty, break
     if #codemasterQueue < 1 then break end
+    --grab random seat from empty seats if available
     if #free > 0 then
       seat = table.remove(free,math.random(1,#free))
     else
       seat = table.remove(swap,math.random(1,#swap))
     end
 
+    --get the first player in the queue
     player = findPlayerBySteamID(codemasterQueue[1].steam_id)
+
+    --if they are selected to stay, save them to reinsert later
     if codemasterQueue[1].stay then
       table.insert(reinsert,table.remove(codemasterQueue,1))
     else
@@ -743,21 +750,27 @@ local players = {}
     end
 
     if not Player[seat].seated then
+        --if the seat is empty, we only have to seat the player there
       player.changeColor(seat)
     elseif not player.color == seat then
+      -- if the seat is occupied, get the player that is currently sitting there
       oldPlayer = Player[seat]
+      --get the color of queued player
       oldColor = player.color
 
+      --change the player in the seat to grey
       oldPlayer.changeColor("Grey")
       sleep(5)
+      --move the queued player to the seat
       player.changeColor(seat)
       sleep(5)
+      --move the old player to the queued players old seat
       oldPlayer.changeColor(oldColor)
     end
     sleep(5)
   end
 
-  shufflingPlayer = false
+  shufflingPlayers = false
 
   for _, player in ipairs(reinsert) do table.insert(codemasterQueue,player) end
 

--- a/src/Global.-1.ttslua
+++ b/src/Global.-1.ttslua
@@ -780,9 +780,9 @@ local players = {}
       player.changeColor(seat)
     elseif not player.color == seat then
       -- if the seat is occupied, get the player that is currently sitting there
-      local oldPlayer = FindPlayerByColor(seat)
+      local oldPlayer = findPlayerByColor(seat)
       --get the color of queued player
-      oldColor = player.color
+      local oldColor = player.color
       --change the player in the seat to grey
       oldPlayer.changeColor("Grey")
       sleep(5)

--- a/src/Global.-1.ttslua
+++ b/src/Global.-1.ttslua
@@ -778,7 +778,7 @@ local players = {}
     if not Player[seat].seated then
         --if the seat is empty, we only have to seat the player there
       player.changeColor(seat)
-    elseif not player.color == seat then
+    elseif not (player.color == seat) then
       -- if the seat is occupied, get the player that is currently sitting there
       local oldPlayer = findPlayerByColor(seat)
       --get the color of queued player

--- a/src/Global.-1.ttslua
+++ b/src/Global.-1.ttslua
@@ -683,6 +683,12 @@ function shufflePlayers(o, color)
   end
 end
 
+function sleep(s)
+  for i=1,s do
+    coroutine.yield(0)
+  end
+end
+
 function swapCodemasters()
 local players = {}
   -- remove gray or black players from the codemasterQueue
@@ -715,7 +721,6 @@ local players = {}
   shufflingPlayers = true
   for i = 1,2 do
     if #codemasterQueue < 1 then break end
-    count = 0
     if #free > 0 then
       randSeat = math.random(1,#free)
       seat = free[randSeat]
@@ -730,10 +735,7 @@ local players = {}
           end
         end
       end
-      while count < 5 do
-        count = count + 1
-        coroutine.yield(0)
-      end
+      sleep(5)
     else
       randSeat = math.random(1,#swap)
       seat = swap[randSeat]
@@ -741,32 +743,23 @@ local players = {}
       for _, player in ipairs(Player.getPlayers()) do
         if player.steam_id == codemasterQueue[1].steam_id then
           oldPlayer = Player[seat]
-          oldPlayer.changeColor("Grey")
-          while count < 5 do
-            count = count + 1
-            coroutine.yield(0)
-          end
-          count = 0
           oldColor = player.color
-          player.changeColor(seat)
+
           if codemasterQueue[1].stay then
             table.insert(reinsert,table.remove(codemasterQueue,1))
           else
             table.remove(codemasterQueue,1)
           end
-          while count < 5 do
-            count = count + 1
-            coroutine.yield(0)
-          end
-          count = 0
+
+          oldPlayer.changeColor("Grey")
+          sleep(5)
+          player.changeColor(seat)
+          sleep(5)
           oldPlayer.changeColor(oldColor)
         end
       end
-      while count < 5 do
-        count = count + 1
-        coroutine.yield(0)
-      end
     end
+    sleep(5)
   end
 
   shufflingPlayer = false
@@ -776,11 +769,8 @@ local players = {}
   redrawQueue()
 
   -- Delay afterwards
-  count = 0
-  while count < 250 do
-      count = count + 1
-      coroutine.yield(0)
-  end
+
+  sleep(250)
 
   -- Continue game setup if in progress
   if newGameStarting then

--- a/src/Global.-1.ttslua
+++ b/src/Global.-1.ttslua
@@ -1511,6 +1511,16 @@ function deleteclues()
   blueCluesTracker = 0
 end
 
+function onPlayerDisconnect(player)
+  for i, queuePlayer in ipairs(codemasterQueue) do
+    if queuePlayer.steam_id == player.steam_id then
+      table.remove(codemasterQueue, i)
+      break
+    end
+  end
+  redrawQueue()
+end
+
 function onPlayerChangeColor(color)
   -- Change the player's view
   if color != "Grey" then

--- a/src/Global.-1.ttslua
+++ b/src/Global.-1.ttslua
@@ -719,7 +719,7 @@ local players = {}
   local reinsert = {}
 
   for i, seat in ipairs(seats) do
-    if not Player[seat].seated then
+    if not dPlayer[seat].seated then
       table.insert(free, seat)
     else
       table.insert(swap, seat)
@@ -747,7 +747,7 @@ local players = {}
     elseif not player.color == seat then
       oldPlayer = Player[seat]
       oldColor = player.color
-a
+
       oldPlayer.changeColor("Grey")
       sleep(5)
       player.changeColor(seat)

--- a/src/Global.-1.ttslua
+++ b/src/Global.-1.ttslua
@@ -1017,16 +1017,6 @@ function leaveQueue(o, color)
   redrawQueue()
 end
 
-function onPlayerDisconnect(player)
-  for i, player in ipairs(codemasterQueue) do
-    if player.steam_id == player.steam_id then
-      table.remove(codemasterQueue, i)
-      break
-    end
-  end
-  redrawQueue()
-end
-
 function afkCheckLoop()
   if settings.afkDetection.enabled then
     --print(tostring(os.time()))

--- a/src/Global.-1.ttslua
+++ b/src/Global.-1.ttslua
@@ -719,7 +719,7 @@ local players = {}
   local reinsert = {}
 
   for i, seat in ipairs(seats) do
-    if not dPlayer[seat].seated then
+    if not Player[seat].seated then
       table.insert(free, seat)
     else
       table.insert(swap, seat)

--- a/src/Global.-1.ttslua
+++ b/src/Global.-1.ttslua
@@ -709,6 +709,14 @@ function findPlayerBySteamID(steam_id)
   end
 end
 
+function findPlayerByColor(color)
+  for _, player in ipairs(Player.getPlayers()) do
+    if player.color == color then
+      return player
+    end
+  end
+end
+
 function sleep(t)
   for i=1,t do
     coroutine.yield(0)
@@ -758,7 +766,7 @@ local players = {}
     end
 
     --get the first player in the queue
-    player = findPlayerBySteamID(codemasterQueue[1].steam_id)
+    local player = findPlayerBySteamID(codemasterQueue[1].steam_id)
 
     --if they are selected to stay, save them to reinsert later
     if codemasterQueue[1].stay then
@@ -772,10 +780,9 @@ local players = {}
       player.changeColor(seat)
     elseif not player.color == seat then
       -- if the seat is occupied, get the player that is currently sitting there
-      oldPlayer = Player[seat]
+      local oldPlayer = FindPlayerByColor(seat)
       --get the color of queued player
       oldColor = player.color
-
       --change the player in the seat to grey
       oldPlayer.changeColor("Grey")
       sleep(5)
@@ -863,7 +870,6 @@ function startShuffle()
     end
 
     -- Sit players back down
-    count = 0
     for i, seat in ipairs(seats) do
       if settings.codemasterQueue and i <= 2 and #codemasterQueue > 0 then
         for index, player in ipairs(players) do

--- a/src/Global.-1.ttslua
+++ b/src/Global.-1.ttslua
@@ -742,6 +742,7 @@ local players = {}
       table.remove(swap,randSeat)
       for _, player in ipairs(Player.getPlayers()) do
         if player.steam_id == codemasterQueue[1].steam_id then
+          if player == Player[seat] then break end
           oldPlayer = Player[seat]
           oldColor = player.color
 

--- a/src/Global.-1.ttslua
+++ b/src/Global.-1.ttslua
@@ -683,6 +683,14 @@ function shufflePlayers(o, color)
   end
 end
 
+function findPlayerBySteamID(steam_id)
+  for _, player in ipairs(Player.getPlayers()) do
+    if player.steam_id == steam_id then
+      return player
+    end
+  end
+end
+
 function sleep(t)
   for i=1,t do
     coroutine.yield(0)
@@ -704,7 +712,7 @@ local players = {}
 
   local seats = {
     "Blue",
-    "Red",
+    "Red"
   }
   local free = {}
   local swap = {}
@@ -725,40 +733,34 @@ local players = {}
       randSeat = math.random(1,#free)
       seat = free[randSeat]
       table.remove(free,randSeat)
-      for _, player in ipairs(Player.getPlayers()) do
-        if player.steam_id == codemasterQueue[1].steam_id then
-          player.changeColor(seat)
-          if codemasterQueue[1].stay then
-            table.insert(reinsert,table.remove(codemasterQueue,1))
-          else
-            table.remove(codemasterQueue,1)
-          end
-        end
+
+      player = findPlayerBySteamID(codemasterQueue[1].steam_id)
+      player.changeColor(seat)
+      if codemasterQueue[1].stay then
+        table.insert(reinsert,table.remove(codemasterQueue,1))
+      else
+        table.remove(codemasterQueue,1)
       end
-      sleep(5)
     else
       randSeat = math.random(1,#swap)
       seat = swap[randSeat]
       table.remove(swap,randSeat)
-      for _, player in ipairs(Player.getPlayers()) do
-        if player.steam_id == codemasterQueue[1].steam_id then
-          if player == Player[seat] then break end
-          oldPlayer = Player[seat]
-          oldColor = player.color
+      player = findPlayerBySteamID(codemasterQueue[1].steam_id)
+      if player == Player[seat] then break end
+      oldPlayer = Player[seat]
+      oldColor = player.color
 
-          if codemasterQueue[1].stay then
-            table.insert(reinsert,table.remove(codemasterQueue,1))
-          else
-            table.remove(codemasterQueue,1)
-          end
-
-          oldPlayer.changeColor("Grey")
-          sleep(5)
-          player.changeColor(seat)
-          sleep(5)
-          oldPlayer.changeColor(oldColor)
-        end
+      if codemasterQueue[1].stay then
+        table.insert(reinsert,table.remove(codemasterQueue,1))
+      else
+        table.remove(codemasterQueue,1)
       end
+
+      oldPlayer.changeColor("Grey")
+      sleep(5)
+      player.changeColor(seat)
+      sleep(5)
+      oldPlayer.changeColor(oldColor)
     end
     sleep(5)
   end
@@ -839,7 +841,7 @@ function startShuffle()
 
     -- Sit players back down
     count = 0
-    for i, seat in ipairs(seats) do
+    for _, seat in ipairs(seats) do
       if settings.codemasterQueue and i <= 2 and #codemasterQueue > 0 then
         for i, player in ipairs(players) do
           if player.steam_id == codemasterQueue[1].steam_id then

--- a/src/Global.-1.ttslua
+++ b/src/Global.-1.ttslua
@@ -748,12 +748,6 @@ local players = {}
       oldPlayer = Player[seat]
       oldColor = player.color
 
-      if codemasterQueue[1].stay then
-        table.insert(reinsert,table.remove(codemasterQueue,1))
-      else
-        table.remove(codemasterQueue,1)
-      end
-
       oldPlayer.changeColor("Grey")
       sleep(5)
       player.changeColor(seat)

--- a/src/Global.-1.ttslua
+++ b/src/Global.-1.ttslua
@@ -754,6 +754,7 @@ function swapCodemasters()
   end
 
   shufflingPlayers = true
+
   --run up to 2 times
   for i = 1,2 do
     --if the queue is empty, break
@@ -802,7 +803,6 @@ function swapCodemasters()
   redrawQueue()
 
   -- Delay afterwards
-
   sleep(250)
 
   -- Continue game setup if in progress
@@ -834,8 +834,6 @@ function startShuffle()
   end
   if #players > 0 then
 
-    shufflingPlayers = true
-
     local seatColors = {
       "Blue",
       "Red",
@@ -862,6 +860,8 @@ function startShuffle()
         break
       end
     end
+
+    shufflingPlayers = true
 
     -- Stand all player
     for _, player in ipairs(players) do
@@ -891,15 +891,14 @@ function startShuffle()
       sleep(5)
     end
 
-    for _, player in ipairs(reinsert) do table.insert(codemasterQueue,player) end
     shufflingPlayers = false
+
+    for _, player in ipairs(reinsert) do table.insert(codemasterQueue,player) end
 
     redrawQueue()
 
     -- Delay afterwards
-
     sleep(250)
-
 
     -- Continue game setup if in progress
     if newGameStarting then

--- a/src/Global.-1.ttslua
+++ b/src/Global.-1.ttslua
@@ -719,7 +719,7 @@ local players = {}
   local reinsert = {}
 
   for i, seat in ipairs(seats) do
-    if Player[seat].seated then
+    if not Player[seat].seated then
       table.insert(free, seat)
     else
       table.insert(swap, seat)
@@ -747,7 +747,7 @@ local players = {}
     elseif not player.color == seat then
       oldPlayer = Player[seat]
       oldColor = player.color
-
+a
       oldPlayer.changeColor("Grey")
       sleep(5)
       player.changeColor(seat)

--- a/src/Global.-1.ttslua
+++ b/src/Global.-1.ttslua
@@ -864,11 +864,11 @@ function startShuffle()
 
     -- Sit players back down
     count = 0
-    for _, seat in ipairs(seats) do
+    for i, seat in ipairs(seats) do
       if settings.codemasterQueue and i <= 2 and #codemasterQueue > 0 then
-        for i, player in ipairs(players) do
+        for index, player in ipairs(players) do
           if player.steam_id == codemasterQueue[1].steam_id then
-            table.remove(players, i)
+            table.remove(players, index)
             if codemasterQueue[1].stay then
               table.insert(reinsert,table.remove(codemasterQueue,1))
             else

--- a/src/Global.-1.ttslua
+++ b/src/Global.-1.ttslua
@@ -885,9 +885,7 @@ function startShuffle()
           end
         end
       else
-        local playerIndex = math.random(1, #players)
-        local randPlayer = players[playerIndex]
-        table.remove(players, playerIndex)
+        local randPlayer = table.remove(players, math.random(1, #players))
         randPlayer.changeColor(seat)
       end
       sleep(5)

--- a/src/Global.-1.ttslua
+++ b/src/Global.-1.ttslua
@@ -226,28 +226,39 @@ function onload(saveState)
     font_size=500
   }
   local joinButtonParam = {
-      label="Join",
-      click_function="joinQueue",
-      function_owner=self,
-      position={6.75,0.2,2.2},
-      rotation={0,-90,0},
-      height=500,
-      width=2000,
-      font_size=400
-    }
+    label="Join",
+    click_function="joinQueue",
+    function_owner=self,
+    position={6.75,0.2,3.2},
+    rotation={0,-90,0},
+    height=500,
+    width=1400,
+    font_size=400
+  }
+  local joinStayButtonParam = {
+    label="Stay",
+    click_function="joinQueueStay",
+    function_owner=self,
+    position={6.75,0.2,0},
+    rotation={0,-90,0},
+    height=500,
+    width=1400,
+    font_size=400
+  }
   local leaveButtonParam = {
     label="Leave",
     click_function="leaveQueue",
     function_owner=self,
-    position={6.75,0.2,-2.2},
+    position={6.75,0.2,-3.2},
     rotation={0,-90,0},
     height=500,
-    width=2000,
+    width=1400,
     font_size=400
   }
 
   queuePanel.createButton(queueTextParam)
   queuePanel.createButton(joinButtonParam)
+  queuePanel.createButton(joinStayButtonParam)
   queuePanel.createButton(leaveButtonParam)
 
 
@@ -672,10 +683,119 @@ function shufflePlayers(o, color)
   end
 end
 
+function swapCodemasters()
+local players = {}
+  -- remove gray or black players from the codemasterQueue
+  for _, player in ipairs(Player.getPlayers()) do
+    if player.color == "Grey" or player.color == "Black" then
+      for i, queuePlayer in ipairs(codemasterQueue) do
+        if player.steam_id == queuePlayer.steam_id then
+          table.remove(codemasterQueue,i)
+        end
+      end
+    end
+  end
+
+  local seats = {
+    "Blue",
+    "Red",
+  }
+  local free = {}
+  local swap = {}
+  local reinsert = {}
+
+  for i, seat in ipairs(seats) do
+    if seat.seated then
+      table.insert(free, seat)
+    else
+      table.insert(swap, seat)
+    end
+  end
+
+  shufflingPlayer = true
+  for i = 1,2 do
+    if #codemasterQueue < 1 then break end
+    count = 0
+    if #free > 0 then
+      randSeat = math.random(0,#free)
+      seat = free[randSeat]
+      table.remove(free,randSeat)
+      for _, player in ipairs(Player.getPlayers()) do
+        if player.steam_id == codemasterQueue[1].steam_id then
+          player.changeColor(seat)
+          if codemasterQueue[1].stay then
+            table.insert(reinsert,table.remove(codemasterQueue,1))
+          else
+            table.remove(codemasterQueue,1)
+          end
+        end
+      end
+      while count < 5 do
+        count = count + 1
+        coroutine.yield(0)
+      end
+    else
+      randSeat = math.random(0,#swap)
+      seat = swap[randSeat]
+      table.remove(swap,randSeat)
+      for _, player in ipairs(Player.getPlayers()) do
+        if player.steam_id == codemasterQueue[1].steam_id then
+          oldPlayer = Player[seat]
+          oldPlayer.changeColor("Grey")
+          while count < 5 do
+            count = count + 1
+            coroutine.yield(0)
+          end
+          count = 0
+          oldColor = player.color
+          player.changeColor(seat)
+          if codemasterQueue[1].stay then
+            table.insert(reinsert,table.remove(codemasterQueue,1))
+          else
+            table.remove(codemasterQueue,1)
+          end
+          while count < 5 do
+            count = count + 1
+            coroutine.yield(0)
+          end
+          count = 0
+          oldPlayer.changeColor(oldColor)
+        end
+      end
+      while count < 5 do
+        count = count + 1
+        coroutine.yield(0)
+      end
+    end
+  end
+
+  shufflingPlayer = false
+
+  for _, player in ipairs(reinsert) do table.insert(codemasterQueue,player) end
+
+  redrawQueue()
+
+  -- Delay afterwards
+  count = 0
+  while count < 250 do
+      count = count + 1
+      coroutine.yield(0)
+  end
+
+  -- Continue game setup if in progress
+  if newGameStarting then
+    dealCards(cardsToDeal)
+    reset_keymap()
+  end
+
+  return 1
+end
+
 function startShuffle()
   local seatedPlayers = Player.getPlayers()
   local players = {}
   local seats = {}
+  local reinsert = {}
   for _, player in ipairs(seatedPlayers) do
     -- grab all players that aren't gray or black
     if player.color != "Grey" and player.color != "Black" then
@@ -738,7 +858,11 @@ function startShuffle()
         for i, player in ipairs(players) do
           if player.steam_id == codemasterQueue[1].steam_id then
             table.remove(players, i)
-            table.remove(codemasterQueue,1)
+            if codemasterQueue[1].stay then
+              table.insert(reinsert,table.remove(codemasterQueue,1))
+            else
+              table.remove(codemasterQueue,1)
+            end
             player.changeColor(seat)
             break
           end
@@ -756,6 +880,7 @@ function startShuffle()
       count = 0
     end
 
+    for _, player in ipairs(reinsert) do table.insert(codemasterQueue,player) end
     shufflingPlayers = false
 
     redrawQueue()
@@ -805,10 +930,10 @@ function toggleQueue(o, color)
 end
 
 function redrawQueue()
-  -- get number of buttons, ignoring the original 3
-  local nButtons = #queuePanel.getButtons() - 3
+  -- get number of buttons, ignoring the original 4
+  local nButtons = #queuePanel.getButtons() - 4
   -- removing buttons back to front so that indexes don't shift down while we are looping
-  for i = nButtons+2,3,-1 do
+  for i = nButtons+3,4,-1 do
     queuePanel.removeButton(i)
   end
   for i, player in ipairs(codemasterQueue) do
@@ -822,7 +947,9 @@ function redrawQueue()
       width=4200,
       font_size=400
     }
-
+    if player.stay then
+      PlayerButtonParam.color = {0.8,1,0.8}
+    end
     queuePanel.createButton(PlayerButtonParam)
   end
 
@@ -836,13 +963,42 @@ function joinQueue(o, color)
   end
   for _, player in ipairs(codemasterQueue) do
     if Player[color].steam_id == player.steam_id then
+      if player.stay then
+        player.stay = false
+        redrawQueue()
+      end
       return
     end
   end
   local playerInfo =
   {
     steam_id   = Player[color].steam_id,
-    steam_name = Player[color].steam_name
+    steam_name = Player[color].steam_name,
+    stay       = false
+  }
+  table.insert(codemasterQueue,playerInfo)
+  redrawQueue()
+end
+
+function joinQueueStay(o, color)
+  if color == "Black" then
+    Player[color].broadcast("Please switch colors before attempting to join the codemaster queue.", redColor)
+    return
+  end
+  for _, player in ipairs(codemasterQueue) do
+    if Player[color].steam_id == player.steam_id then
+      if not player.stay then
+        player.stay = true
+        redrawQueue()
+      end
+      return
+    end
+  end
+  local playerInfo =
+  {
+    steam_id   = Player[color].steam_id,
+    steam_name = Player[color].steam_name,
+    stay       = true
   }
   table.insert(codemasterQueue,playerInfo)
   redrawQueue()
@@ -1574,6 +1730,9 @@ function findDeck()
               if settings.playerShuffle then
                 cardsToDeal = v
                 startLuaCoroutine(Global, "startShuffle")
+              elseif settings.codemasterQueue then
+                cardsToDeal = v
+                startLuaCoroutine(Global, "swapCodemasters")
               else
                 dealCards(v)
                 reset_keymap()

--- a/src/Global.-1.ttslua
+++ b/src/Global.-1.ttslua
@@ -724,7 +724,7 @@ function sleep(t)
 end
 
 function swapCodemasters()
-local players = {}
+  local players = {}
   -- remove gray or black players from the codemasterQueue
   for _, player in ipairs(Player.getPlayers()) do
     if player.color == "Grey" or player.color == "Black" then


### PR DESCRIPTION
Codemaster queue:
* Can now be used with shuffle disabled
* Added "Stay" button that allows people to automatically be re-queued after their turn
* Fixed onPlayerDisconnect to remove players from the queue when they leave

Added helper functions:
* sleep(ticks) to replace while/yield loops
* FindPlayerBySteamID
* FindPlayerByColor : this returns a proper player object, Player[color] only provides a weird version that resets if the player changes colors.

A few other cleanup changes  