### PR TITLE
fix "always true" boolean statement

### DIFF
--- a/src/Custom Assetbundle.0a61c6.ttslua
+++ b/src/Custom Assetbundle.0a61c6.ttslua
@@ -777,7 +777,7 @@ function swapCodemasters()
 
     if nextPlayer ~= nil then
       -- Check to see they were seated
-      if nextPlayer.seated and not nextPlayer.blindfolded then
+      if nextPlayer.color != "Grey" and nextPlayer.color != "Black" and not nextPlayer.blindfolded then
         if nextInQueue.stay then
           table.insert(requeue, nextPlayer)
         end


### PR DESCRIPTION
"seated" is always true for player instances retrieved from getPlayers() which is the case in this line.
The seated variable is only useful for player instances created by "Player[color]" syntax to check if there is a player seated in a specific colour.